### PR TITLE
Let Renovate propose updates for all Kotlin version

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,12 +6,6 @@
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true
-    },
-    {
-       "matchPackagePrefixes": [
-          "org.jetbrains.kotlin"
-       ],
-       "allowedVersions": "<1.7"
     }
   ]
 }


### PR DESCRIPTION
Also, kotest is already on Kotlin 2.0.20, so binding it to Kotlin < 1.7 makes very little sense.
This way, updates would be proposed, and we would learn quickly when an incompatibility arises.